### PR TITLE
Title concatenation without space

### DIFF
--- a/lib/solrmarc/src/org/solrmarc/index/SolrIndexer.java
+++ b/lib/solrmarc/src/org/solrmarc/index/SolrIndexer.java
@@ -1926,6 +1926,9 @@ public class SolrIndexer
           Subfield f = iter.next(); 
           char code = f.getCode();
           if ( code == 'a' || code == 'b' || code == 'k' ) {
+             if(titleBuilder.length() > 0) {
+               titleBuilder.append(" ");
+             }  
              titleBuilder.append(f.getData()); 
           }
         }        


### PR DESCRIPTION
Title fields are concatenated without space despite stating otherwise in the javaDoc.