### PR TITLE
Reuse prepared statements.

### DIFF
--- a/examples/GenericVuFind/src/org/solrmarc/index/VuFindIndexer.java
+++ b/examples/GenericVuFind/src/org/solrmarc/index/VuFindIndexer.java
@@ -324,7 +324,7 @@ public class VuFindIndexer extends SolrIndexer
     /**
      * Establish UpdateDateTracker object if not already available.
      */
-    private void loadUpdateDateTracker()
+    private void loadUpdateDateTracker() throws java.sql.SQLException
     {
         if (tracker == null) {
             connectToDatabase();
@@ -1428,11 +1428,11 @@ public class VuFindIndexer extends SolrIndexer
      */
     public UpdateDateTracker updateTracker(String core, String id, java.util.Date latestTransaction)
     {
-        // Initialize date tracker if not already initialized:
-        loadUpdateDateTracker();
-
         // Update the database (if necessary):
         try {
+            // Initialize date tracker if not already initialized:
+            loadUpdateDateTracker();
+
             tracker.index(core, id, latestTransaction);
         } catch (java.sql.SQLException e) {
             // If we're in the process of shutting down, an error is expected:


### PR DESCRIPTION
At @haschart's suggestion, this PR reuses prepared statements in an effort to make database access more efficient. I haven't noticed a significant difference, but it may be worth committing anyway. I'm opening this as a pull request so that it can be tested more thoroughly before making its way into master.

TODO:
- [ ] Test thoroughly