### PR TITLE
Concurrency systemproperties fix

### DIFF
--- a/lib/solrmarc/src/org/solrmarc/marc/MarcHandler.java
+++ b/lib/solrmarc/src/org/solrmarc/marc/MarcHandler.java
@@ -56,6 +56,7 @@ public abstract class MarcHandler {
 	
 	public void init(String args[])
 	{
+      sychronized(MarcHandler.class) {
         String configProperties = GetDefaultConfig.getConfigName("config.properties");
 
         List<String> addnlArgList = new ArrayList<String>();
@@ -126,6 +127,7 @@ public abstract class MarcHandler {
         {
             loadIndexer(indexerName, indexerProps); 
         }
+      }  
 	}
 		
     /** 


### PR DESCRIPTION
When processing more than one file at once, there are several race conditions when reading and writing to system properties since those are static and shared amongst all processes.