### PR TITLE
Solrsearchsupport

### DIFF
--- a/src/org/solrmarc/callnum/CallNumUtils.java
+++ b/src/org/solrmarc/callnum/CallNumUtils.java
@@ -47,7 +47,7 @@ public final class CallNumUtils {
      *      e.g. "1987" "15th"
      * LC call numbers can't begin with I, O, W, X, or Y
      */
-    public static final String LC_CLASS_REQ_REGEX = "[A-Z&&[^IOWXY]]{1}[A-Z]{0,2} *\\d+(\\.\\d+)?";
+    public static final String LC_CLASS_REQ_REGEX = "(([B-Z&&[^IOWXY]]{1}[A-Z]{0,2})|(A[CEGIMNPSYZ])) *\\d+(\\.\\d+)?";
 
     /**
      * non-cutter text that can appear before or after cutters
@@ -303,7 +303,7 @@ public final class CallNumUtils {
         Matcher matcher = pattern.matcher(rawCallnum);
 
         if (matcher.find())
-            result = matcher.group(6).trim();
+            result = matcher.group(9).trim();
 
         // if no well formed cutter, take the chunk after last period or space
         //  if it begins with a letter
@@ -780,7 +780,7 @@ public final class CallNumUtils {
         String result = null;
         if (cutter != null && cutter.length() > 0) {
             String cutLets = getLCstartLetters(cutter);
-            String cutDigs = cutter.substring(cutLets.length());
+            String cutDigs = cutter.substring(cutLets == null ? 0 : cutLets.length());
             String norm = null;
             if (cutDigs != null && cutDigs.length() > 0) {
                 try {

--- a/src/org/solrmarc/debug/SolrMarcDebug.java
+++ b/src/org/solrmarc/debug/SolrMarcDebug.java
@@ -31,12 +31,14 @@ import javax.swing.text.StyleConstants;
 
 import org.marc4j.MarcError;
 import org.marc4j.MarcReader;
+import org.marc4j.MarcReaderConfig;
+import org.marc4j.MarcReaderFactory;
 import org.marc4j.marc.Record;
 import org.solrmarc.driver.BootableMain;
 import org.solrmarc.index.indexer.AbstractValueIndexer;
 import org.solrmarc.index.indexer.IndexerSpecException;
 import org.solrmarc.index.indexer.ValueIndexerFactory;
-import org.solrmarc.marc.MarcReaderFactory;
+//import org.solrmarc.marc.MarcReaderFactory;
 import org.solrmarc.tools.PropertyUtils;
 
 import java.awt.event.ActionListener;
@@ -76,6 +78,7 @@ public class SolrMarcDebug extends BootableMain
     String previousConfigText = "";
     List<AbstractValueIndexer<?>> indexers = null;
     Properties readerProps = new Properties();
+    MarcReaderConfig readerConfig;
     static int[] fontSizeArray = { 8, 10, 12, 14, 18, 22, 28, 36, 42 };
     /**
      * Launch the application.
@@ -131,6 +134,13 @@ public class SolrMarcDebug extends BootableMain
         {
             // TODO Auto-generated catch block
             e2.printStackTrace();
+        }
+        try {
+            readerConfig = new MarcReaderConfig(readerProps);
+        }
+        catch (NoClassDefFoundError cnf)
+        {
+            readerConfig = null;
         }
 
         recordMap = new LinkedHashMap<String, Record>();
@@ -468,7 +478,8 @@ public class SolrMarcDebug extends BootableMain
         String firstId = null;
         try
         {
-            reader = MarcReaderFactory.instance().makeReader(readerProps, ValueIndexerFactory.instance().getHomeDirs(), new FileInputStream(marcFile));
+            reader = MarcReaderFactory.makeReader(readerConfig, new FileInputStream(marcFile));
+
             while (reader.hasNext())
             {
                 Record record = reader.next();
@@ -486,7 +497,7 @@ public class SolrMarcDebug extends BootableMain
             }
             if (pointToFirst) marcIdentifier.setSelectedItem(firstId);
         }
-        catch (FileNotFoundException e1)
+        catch (IOException e1)
         {
             // TODO Auto-generated catch block
             e1.printStackTrace();

--- a/src/org/solrmarc/driver/Boot.java
+++ b/src/org/solrmarc/driver/Boot.java
@@ -409,22 +409,28 @@ public class Boot
     {
         for (String libdirname : addnlLibDirStrs)
         {
-            boolean found = false;
             File libDir = new File(libdirname);
             if (!libDir.isAbsolute())
             {
-                for (String homeDir : homeDirStrs)
+                logger.debug("Number of homeDirStrs: " + homeDirStrs.length);
+                logger.debug("homeDirStrs[0]: " + homeDirStrs[0]);
+                logger.debug("homeDirStrs[1]: " + homeDirStrs[1]);
+                for (int i = homeDirStrs.length - 1; i >= 0; i--)
                 {
+                    String homeDir = homeDirStrs[i];
+                    logger.debug("Checking for jars files in directory: " + homeDir + "/" + libdirname);
                     libDir = new File(homeDir, libdirname);
                     if (libDir.exists() && libDir.isDirectory() && libDir.listFiles().length > 0)
                     {
-                        found = true;
-                        break;
+                        logger.debug("Adding jars files in directory: " + libDir.getAbsolutePath());
+                        extendClasspathWithLibJarDir(libDir, null);
+                        extendClasspathWithDirOfClasses(libDir);
                     }
                 }
             }
-            if (found)
+            else if (libDir.exists() && libDir.isDirectory() && libDir.listFiles().length > 0)
             {
+                logger.debug("Adding jars files in directory: " + libDir.getAbsolutePath());
                 extendClasspathWithLibJarDir(libDir, null);
                 extendClasspathWithDirOfClasses(libDir);
             }

--- a/src/org/solrmarc/driver/BootableMain.java
+++ b/src/org/solrmarc/driver/BootableMain.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
 import org.solrmarc.index.indexer.IndexerSpecException;
 
 import joptsimple.OptionException;
@@ -124,6 +126,8 @@ public class BootableMain
         }
         System.setProperty("solrmarc.home.dir", homeDirStrs[0]);
 
+        reInitLogging(homeDirStrs);
+
         File solrJPath = ((options.has(solrjDir)) ? options.valueOf(solrjDir) : new File("lib-solrj"));
 
         try {
@@ -158,4 +162,21 @@ public class BootableMain
             System.exit(10);
         }
     }
+    
+    private static void reInitLogging(String[] homeDirs)
+    {
+        for (String dir : homeDirs)
+        {
+            File log4jProps = new File(dir, "log4j.properties");
+            if (log4jProps.exists())
+            {
+                LogManager.resetConfiguration();
+                PropertyConfigurator.configure(log4jProps.getAbsolutePath());
+                return;
+            }
+        }
+    }
+
+
+
 }

--- a/src/org/solrmarc/driver/Indexer.java
+++ b/src/org/solrmarc/driver/Indexer.java
@@ -472,7 +472,7 @@ public class Indexer
             {
                 solrProxy.delete(recCtrlNum);
             }
-            catch (IOException e)
+            catch (SolrRuntimeException e)
             {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
@@ -483,7 +483,7 @@ public class Indexer
             logger.info("Commiting updates to Solr");
             solrProxy.commit(false);
         }
-        catch (IOException e)
+        catch (SolrRuntimeException e)
         {
         }
     }

--- a/src/org/solrmarc/driver/Indexer.java
+++ b/src/org/solrmarc/driver/Indexer.java
@@ -109,6 +109,7 @@ public class Indexer
         {
             RecordAndCnt recordAndCnt = getRecord(reader);
             if (recordAndCnt == null) break;
+            logger.debug("record read : " + recordAndCnt.getRecord().getControlNumber());
 
             RecordAndDoc recDoc = null;
             try {

--- a/src/org/solrmarc/driver/MarcReaderThread.java
+++ b/src/org/solrmarc/driver/MarcReaderThread.java
@@ -32,6 +32,7 @@ public class MarcReaderThread extends Thread
         {
             recordAndCnt = indexer.getRecord(reader);
             if (recordAndCnt == null) break;
+            logger.debug("record read : " + recordAndCnt.getRecord().getControlNumber());
             try {
                 readQ.put(recordAndCnt);
             } catch (InterruptedException e) {

--- a/src/org/solrmarc/driver/RecordFixer.java
+++ b/src/org/solrmarc/driver/RecordFixer.java
@@ -14,6 +14,8 @@ import org.marc4j.MarcError;
 import org.marc4j.MarcException;
 import org.marc4j.MarcJsonWriter;
 import org.marc4j.MarcReader;
+import org.marc4j.MarcReaderConfig;
+import org.marc4j.MarcReaderFactory;
 import org.marc4j.MarcStreamWriter;
 import org.marc4j.MarcWriter;
 import org.marc4j.MarcXmlWriter;
@@ -21,7 +23,7 @@ import org.marc4j.converter.impl.UnicodeToAnsel;
 import org.marc4j.marc.Record;
 import org.solrmarc.index.indexer.AbstractValueIndexer;
 import org.solrmarc.index.indexer.ValueIndexerFactory;
-import org.solrmarc.marc.MarcReaderFactory;
+//import org.solrmarc.marc.MarcReaderFactory;
 import org.solrmarc.solr.SolrProxy;
 import org.solrmarc.tools.PropertyUtils;
 
@@ -31,7 +33,8 @@ public class RecordFixer extends BootableMain
     public final static Logger logger = Logger.getLogger(IndexDriver.class);
 
     Properties readerProps;
-
+    MarcReaderConfig readerConfig;
+    
     List<AbstractValueIndexer<?>> indexers;
     Indexer indexer;
     MarcReader reader;
@@ -95,11 +98,18 @@ public class RecordFixer extends BootableMain
         {
             readerProps.load(PropertyUtils.getPropertyFileInputStream(propertyFileURLStr));
         }
+        readerConfig = new MarcReaderConfig(readerProps);
     }
 
     public void configureReader(List<String> inputFilenames)
     {
-        reader = MarcReaderFactory.instance().makeReader(readerProps, ValueIndexerFactory.instance().getHomeDirs(), inputFilenames);
+        try {
+            reader = MarcReaderFactory.makeReader(readerConfig, ValueIndexerFactory.instance().getHomeDirs(), inputFilenames);
+        }
+        catch (IOException e)
+        {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
     }
 
     public void configureOutput(String mode)

--- a/src/org/solrmarc/index/indexer/ValueIndexerFactory.java
+++ b/src/org/solrmarc/index/indexer/ValueIndexerFactory.java
@@ -71,7 +71,6 @@ public class ValueIndexerFactory
         if (theFactory != null && Arrays.equals(homeDirStrs, theFactory.homeDirStrs))
             return(theFactory);
 
-        initLogging(homeDirStrs);
         theFactory = new ValueIndexerFactory(homeDirStrs);
         try
         {
@@ -121,21 +120,6 @@ public class ValueIndexerFactory
         compileTool = new JavaValueExtractorUtils(dirsJavaSource);
         compileTool.compileSources();
     }
-
-    private static void initLogging(String[] homeDirs)
-    {
-        for (String dir : homeDirs)
-        {
-            File log4jProps = new File(dir, "log4j.properties");
-            if (log4jProps.exists())
-            {
-                LogManager.resetConfiguration();
-                PropertyConfigurator.configure(log4jProps.getAbsolutePath());
-                return;
-            }
-        }
-    }
-
 
     public Class<?>[] getCompiledClasses()
     {

--- a/src/org/solrmarc/index/utils/FastClasspathUtils.java
+++ b/src/org/solrmarc/index/utils/FastClasspathUtils.java
@@ -33,7 +33,7 @@ public class FastClasspathUtils
                 @Override
                 public void processMatch(Class<? extends AbstractValueExtractorFactory> matchingClass) 
                 {
-//                    logger.debug("Subclass of AbstractValueExtractorFactory: " + matchingClass);
+                    logger.debug("Subclass of AbstractValueExtractorFactory: " + matchingClass);
                     extractors.add(matchingClass);
                 }
             })
@@ -42,7 +42,7 @@ public class FastClasspathUtils
                 @Override
                 public void processMatch(Class<? extends AbstractValueMappingFactory> matchingClass) 
                 {
-//                    logger.debug("Subclass of AbstractValueMappingFactory: " + matchingClass);
+                    logger.debug("Subclass of AbstractValueMappingFactory: " + matchingClass);
                     mappers.add(matchingClass);
                 }
             })
@@ -51,7 +51,7 @@ public class FastClasspathUtils
                 @Override
                 public void processMatch(Class<? extends Mixin> matchingClass) 
                 {
-//                    logger.debug("Subclass of Mixin: " + matchingClass);
+                    logger.debug("Subclass of Mixin: " + matchingClass);
                     mixins.add(matchingClass);
                 }
             });

--- a/src/org/solrmarc/marc/SolrMarcMarcReaderFactory.java
+++ b/src/org/solrmarc/marc/SolrMarcMarcReaderFactory.java
@@ -12,7 +12,7 @@ import org.marc4j.*;
 import org.solrmarc.marc.MarcUnprettyXmlReader;
 import org.solrmarc.tools.PropertyUtils;
 
-public class MarcReaderFactory {
+public class SolrMarcMarcReaderFactory {
 
 	protected boolean verbose = false;
 
@@ -29,15 +29,15 @@ public class MarcReaderFactory {
 	protected String unicodeNormalize = null;
 
     // Initialize logging category
-    static Logger logger = Logger.getLogger(MarcReaderFactory.class.getName());
+    static Logger logger = Logger.getLogger(SolrMarcMarcReaderFactory.class.getName());
 
-	private MarcReaderFactory()
+	private SolrMarcMarcReaderFactory()
 	{
 	}
 
-	static MarcReaderFactory theFactory = new MarcReaderFactory();
+	static SolrMarcMarcReaderFactory theFactory = new SolrMarcMarcReaderFactory();
 
-	public static MarcReaderFactory instance()
+	public static SolrMarcMarcReaderFactory instance()
 	{
 	    return(theFactory);
 	}
@@ -155,7 +155,8 @@ public class MarcReaderFactory {
         inputTypeXML = false;
         inputTypeBinary = false;
         inputTypeJSON = false;
-        if (filestart.substring(0,  5).equalsIgnoreCase("<?xml"))            inputTypeXML = true;
+        if (numRead == -1 || filestart.length() == 0)                        inputTypeBinary = true;
+        else if (filestart.substring(0,  5).equalsIgnoreCase("<?xml"))       inputTypeXML = true;
         else if (filestart.startsWith("{"))                                  inputTypeJSON = true;
         else if (filestart.substring(0,  5).matches("\\d\\d\\d\\d\\d"))      inputTypeBinary = true;
         else if (filestart.contains("<?xml") || filestart.contains("<?XML")) inputTypeXML = true;

--- a/src/org/solrmarc/solr/DevNullProxy.java
+++ b/src/org/solrmarc/solr/DevNullProxy.java
@@ -1,6 +1,9 @@
 package org.solrmarc.solr;
 
 import java.util.Collection;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
 
 public class DevNullProxy extends SolrProxy
@@ -8,13 +11,13 @@ public class DevNullProxy extends SolrProxy
     public DevNullProxy()
     {
     }
-    
+
     @Override
     public int addDoc(SolrInputDocument inputDoc)
     {
         return(1);
     }
-    
+
     @Override
     public int addDocs(Collection<SolrInputDocument> docQ)
     {
@@ -25,7 +28,7 @@ public class DevNullProxy extends SolrProxy
         }
         return(num);
     }
-    
+
     @Override
     public void commit(boolean optimize)
     {
@@ -34,5 +37,11 @@ public class DevNullProxy extends SolrProxy
     @Override
     public void delete(String id)
     {
+    }
+
+    @Override
+    public QueryResponse query(SolrQuery params)
+    {
+        return null;
     }
 }

--- a/src/org/solrmarc/solr/SolrClientProxy.java
+++ b/src/org/solrmarc/solr/SolrClientProxy.java
@@ -5,6 +5,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
@@ -18,7 +20,8 @@ public class SolrClientProxy extends SolrProxy
     Method commit;
     Method optimize;
     Method delete;
-        
+    Method query;
+
     public SolrClientProxy(Object httpsolrclient)
     {
         this.solrclient = httpsolrclient;
@@ -29,6 +32,7 @@ public class SolrClientProxy extends SolrProxy
             this.commit = getMethod(solrclient, "commit");
             this.optimize = getMethod(solrclient, "optimize");
             this.delete = getMethod(solrclient, "deleteById", String.class);
+            this.query = getMethod(solrclient, "query", SolrQuery.class);
         }
         catch (NoSuchMethodException | SecurityException e)
         {
@@ -71,14 +75,6 @@ public class SolrClientProxy extends SolrProxy
         {
             throw(new SolrRuntimeException("SolrserverException", e));
         }
-//        catch (SolrServerException e)
-//        {
-//            throw(new SolrRuntimeException("SolrserverException", e));
-//        }
-//        catch (IOException e)
-//        {
-//            throw(new SolrRuntimeException("SolrserverException", e));
-//        }
         catch (IllegalAccessException e)
         {
             throw(new SolrRuntimeException("SolrserverException", e));
@@ -92,7 +88,7 @@ public class SolrClientProxy extends SolrProxy
             throw(new SolrRuntimeException("SolrserverException", e));
         }
     }
-    
+
     @Override
     public int addDocs(Collection<SolrInputDocument> docQ)
     {
@@ -124,6 +120,7 @@ public class SolrClientProxy extends SolrProxy
         }
     }
 
+    @Override
     public void commit(boolean doOptimize) throws IOException
     {
         try
@@ -133,10 +130,6 @@ public class SolrClientProxy extends SolrProxy
             else
                 commit.invoke(solrclient);
         }
-//        catch (SolrServerException e)
-//        {
-//            throw(new SolrRuntimeException("SolrserverException", e));
-//        }
         catch (IllegalAccessException e)
         {
             throw(new SolrRuntimeException("SolrserverException", e));
@@ -151,16 +144,13 @@ public class SolrClientProxy extends SolrProxy
         }
     }
 
+    @Override
     public void delete(String id) throws IOException
     {
         try
         {
             delete.invoke(solrclient, id);
         }
-//        catch (SolrServerException e)
-//        {
-//            throw(new SolrRuntimeException("SolrserverException", e));
-//        }
         catch (IllegalAccessException e)
         {
             throw(new SolrRuntimeException("SolrserverException", e));
@@ -173,6 +163,21 @@ public class SolrClientProxy extends SolrProxy
         {
             throw(new SolrRuntimeException("SolrserverException", e));
         }
+    }
+
+    @Override
+    public QueryResponse query(SolrQuery params) throws IOException
+    {
+        QueryResponse result = null;
+        try
+        {
+            result = (QueryResponse)query.invoke(solrclient, params);
+        }
+        catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e)
+        {
+            throw(new SolrRuntimeException("SolrserverException", e));
+        }
+        return result;
     }
 
 }

--- a/src/org/solrmarc/solr/SolrClientProxy.java
+++ b/src/org/solrmarc/solr/SolrClientProxy.java
@@ -10,6 +10,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 
 public class SolrClientProxy extends SolrProxy
@@ -32,7 +33,7 @@ public class SolrClientProxy extends SolrProxy
             this.commit = getMethod(solrclient, "commit");
             this.optimize = getMethod(solrclient, "optimize");
             this.delete = getMethod(solrclient, "deleteById", String.class);
-            this.query = getMethod(solrclient, "query", SolrQuery.class);
+            this.query = getMethod(solrclient, "query", SolrParams.class);
         }
         catch (NoSuchMethodException | SecurityException e)
         {

--- a/src/org/solrmarc/solr/SolrClientProxy.java
+++ b/src/org/solrmarc/solr/SolrClientProxy.java
@@ -121,10 +121,10 @@ public class SolrClientProxy extends SolrProxy
     }
 
     @Override
-    public void commit(boolean doOptimize) throws IOException
+    public void commit(boolean doOptimize)
     {
         try
-        {  
+        {
             if (doOptimize)
                 optimize.invoke(solrclient);
             else
@@ -145,7 +145,7 @@ public class SolrClientProxy extends SolrProxy
     }
 
     @Override
-    public void delete(String id) throws IOException
+    public void delete(String id)
     {
         try
         {
@@ -166,7 +166,7 @@ public class SolrClientProxy extends SolrProxy
     }
 
     @Override
-    public QueryResponse query(SolrQuery params) throws IOException
+    public QueryResponse query(SolrQuery params)
     {
         QueryResponse result = null;
         try

--- a/src/org/solrmarc/solr/SolrProxy.java
+++ b/src/org/solrmarc/solr/SolrProxy.java
@@ -38,13 +38,13 @@ public abstract class SolrProxy
      * @param id
      *            the unique identifier of the document to be deleted
      */
-    public abstract void delete(String id) throws IOException;
+    public abstract void delete(String id);
 
     /**
      * commit changes to the index
      */
-    public abstract void commit(boolean optimize) throws IOException;
+    public abstract void commit(boolean optimize);
 
-    public abstract QueryResponse query(SolrQuery params) throws IOException;
+    public abstract QueryResponse query(SolrQuery params);
 
 }

--- a/src/org/solrmarc/solr/SolrProxy.java
+++ b/src/org/solrmarc/solr/SolrProxy.java
@@ -3,7 +3,9 @@ package org.solrmarc.solr;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
 
 public abstract class SolrProxy
@@ -25,7 +27,7 @@ public abstract class SolrProxy
      *            - map of field names and values to add to the document
      * @return a string representation of the document
      */
-    
+
     public abstract int addDoc(SolrInputDocument document);
 
     public abstract int addDocs(Collection<SolrInputDocument> docQ);
@@ -42,5 +44,7 @@ public abstract class SolrProxy
      * commit changes to the index
      */
     public abstract void commit(boolean optimize) throws IOException;
+
+    public abstract QueryResponse query(SolrQuery params) throws IOException;
 
 }

--- a/src/org/solrmarc/solr/SolrServerProxy.java
+++ b/src/org/solrmarc/solr/SolrServerProxy.java
@@ -3,8 +3,10 @@ package org.solrmarc.solr;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
@@ -13,12 +15,12 @@ import org.apache.solr.common.util.NamedList;
 public class SolrServerProxy extends SolrProxy
 {
     final SolrServer solrserver;
-    
+
     public SolrServerProxy(SolrServer solrserver)
     {
         this.solrserver = solrserver;
     }
-    
+
     public SolrServerProxy(Object httpsolrserver)
     {
         this.solrserver = (SolrServer)httpsolrserver;
@@ -47,7 +49,7 @@ public class SolrServerProxy extends SolrProxy
             throw(new SolrRuntimeException("SolrserverException", e));
         }
     }
-    
+
     @Override
     public int addDocs(Collection<SolrInputDocument> docQ)
     {
@@ -78,7 +80,7 @@ public class SolrServerProxy extends SolrProxy
     public void commit(boolean optimize) throws IOException
     {
         try
-        {  
+        {
             if (optimize)
                 solrserver.optimize();
             else
@@ -95,6 +97,19 @@ public class SolrServerProxy extends SolrProxy
         try
         {
             solrserver.deleteById(id);
+        }
+        catch (SolrServerException e)
+        {
+            throw(new SolrRuntimeException("SolrserverException", e));
+        }
+    }
+
+    @Override
+    public QueryResponse query(SolrQuery params) throws IOException
+    {
+        try
+        {
+            return solrserver.query(params);
         }
         catch (SolrServerException e)
         {

--- a/src/org/solrmarc/solr/SolrServerProxy.java
+++ b/src/org/solrmarc/solr/SolrServerProxy.java
@@ -77,7 +77,7 @@ public class SolrServerProxy extends SolrProxy
         }
     }
 
-    public void commit(boolean optimize) throws IOException
+    public void commit(boolean optimize)
     {
         try
         {
@@ -90,9 +90,13 @@ public class SolrServerProxy extends SolrProxy
         {
             throw(new SolrRuntimeException("SolrserverException", e));
         }
+        catch (IOException e)
+        {
+            throw(new SolrRuntimeException("IOException", e));
+        }
     }
 
-    public void delete(String id) throws IOException
+    public void delete(String id)
     {
         try
         {
@@ -102,10 +106,14 @@ public class SolrServerProxy extends SolrProxy
         {
             throw(new SolrRuntimeException("SolrserverException", e));
         }
+        catch (IOException e)
+        {
+            throw(new SolrRuntimeException("IOException", e));
+        }
     }
 
     @Override
-    public QueryResponse query(SolrQuery params) throws IOException
+    public QueryResponse query(SolrQuery params)
     {
         try
         {

--- a/src/org/solrmarc/solr/StdOutProxy.java
+++ b/src/org/solrmarc/solr/StdOutProxy.java
@@ -5,7 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
 
 public class StdOutProxy extends SolrProxy
@@ -51,22 +52,21 @@ public class StdOutProxy extends SolrProxy
         return(num);
     }
 
-    public SolrServer getSolrServer()
-    {
-        return(null);
-    }
-
+    @Override
     public void commit(boolean optimize)
     {
         output.flush();
     }
 
+    @Override
     public void delete(String id)
     {
     }
 
-    public void deleteAllDocs()
+    @Override
+    public QueryResponse query(SolrQuery params)
     {
+        return null;
     }
 
 }


### PR DESCRIPTION
Merging branch solrsearchsupport into master.   This includes commits to support searching through the Solr Proxy classes to allow a mixin to perform lookups in an existing solr index.    Also it included bug-fixes related to multiple directories of local libraries, and uses the MarcReaderFactory class in the newest versions of marc4j and deprecates the similar code in the SolrMarc project.