### PR TITLE
Don't add duplicate home directories.

### DIFF
--- a/src/org/solrmarc/driver/BootableMain.java
+++ b/src/org/solrmarc/driver/BootableMain.java
@@ -112,8 +112,10 @@ public class BootableMain
                 {
                     hasDefDir = true;
                 }
-                homeDirList.add(dirAsFile.getAbsolutePath());
-                logger.debug("Adding directory: " + dirAsFile.getAbsolutePath());
+                if (!homeDirList.contains(dirAsFile.getAbsolutePath())) {
+                    homeDirList.add(dirAsFile.getAbsolutePath());
+                    logger.debug("Adding directory: " + dirAsFile.getAbsolutePath());
+                }
             }
             if (!hasDefDir)
             {


### PR DESCRIPTION
- This was causing a custom index java compilation problem by presenting the directory list in the wrong order.