### PR TITLE
Javadoc ant task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
+/javadoc/
 /logs/
 /.settings/
 *.log

--- a/build.xml
+++ b/build.xml
@@ -535,7 +535,9 @@
 	<target name="javadoc" description="Build javadoc">
 		<mkdir dir="${doc.dir}"/>
 		<javadoc sourcepath="${src.dir}"
-	         destdir="${doc.dir}"
+			destdir="${doc.dir}"
+			windowtitle="SolrMarc API"
+			doctitle="SolrMarc API"
 			>
             <classpath >
                 <fileset dir="${lib.dir}">

--- a/build.xml
+++ b/build.xml
@@ -532,6 +532,24 @@
         </zip>
     </target>
 
+	<target name="javadoc" description="Build javadoc">
+		<mkdir dir="${doc.dir}"/>
+		<javadoc sourcepath="${src.dir}"
+	         destdir="${doc.dir}"
+			>
+            <classpath >
+                <fileset dir="${lib.dir}">
+                    <include name="**/*.jar"/>
+                </fileset>
+            </classpath>
+            <classpath >
+                <fileset dir="${lib.solrj.dir}">
+                    <include name="**/*.jar"/>
+                </fileset>
+            </classpath>
+		</javadoc>
+	</target>
+
     <target name="clean" description="clean up">
         <!-- Delete the ${build} and ${dist} directory trees -->
         <delete dir="${build.dir}" failonerror="false" />

--- a/src/org/solrmarc/callnum/CallNumUtils.java
+++ b/src/org/solrmarc/callnum/CallNumUtils.java
@@ -153,6 +153,9 @@ public final class CallNumUtils {
     /**
      * given a possible Library of Congress call number value, determine if it
      *  matches the pattern of an LC call number
+     *  
+     *  @param possLCval  possible LC call number to check
+     *  @return	          whether call number looks like LC
      */
     public static final boolean isValidLC(String possLCval)
     {
@@ -164,6 +167,9 @@ public final class CallNumUtils {
     /**
      * given a possible Dewey call number value, determine if it
      *  matches the pattern of an Dewey call number
+     *  
+     *  @param possDeweyVal  possible Dewey call number to check
+     *  @return	          whether call number looks like Dewey
      */
     public static final boolean isValidDeweyWithCutter(String possDeweyVal)
     {
@@ -175,6 +181,9 @@ public final class CallNumUtils {
    /**
      * given a possible Dewey call number value, determine if it
      *  matches the pattern of an Dewey call number
+     *  
+     *  @param possDeweyVal  possible Dewey call number to check
+     *  @return	          whether call number looks like Dewey
      */
     public static final boolean isValidDewey(String possDeweyVal)
     {
@@ -186,6 +195,9 @@ public final class CallNumUtils {
     /**
      * return the portion of the call number string that occurs before the
      *  Cutter, NOT including any class suffixes occuring before the cutter
+     *  
+     *  @param callnum  call number
+     *  @return         the portion before the cutter
      */
     public static final String getPortionBeforeCutter(String callnum) {
 
@@ -206,7 +218,10 @@ public final class CallNumUtils {
 
     /**
      * return the portion of the LC call number string that occurs before the
-     *  Cutter.
+     * Cutter.
+     *  
+     * @param callnum  call number
+     * @return         the portion before the cutter
      */
     public static final String getLCB4FirstCutter(String callnum) {
         String result = null;
@@ -236,6 +251,9 @@ public final class CallNumUtils {
     /**
      * Given a raw LC call number, return the initial letters (before any
      *  numbers)
+     *  
+     *  @param rawLCcallnum  call number
+     *  @return         initial letters of classification
      */
     public static String getLCstartLetters(String rawLCcallnum) {
         String result = null;
@@ -251,7 +269,9 @@ public final class CallNumUtils {
      * return the numeric portion of the required portion of the LC classification.
      *  LC classification requires
      *    1-3 capital letters followed by  float number (may be an integer)
-     * @param rawLCcallnum
+     *    
+     * @param rawLCcallnum call number
+     * @return             numeric portion of classification
      */
     public static String getLCClassDigits(String rawLCcallnum) {
         String result = null;
@@ -268,7 +288,9 @@ public final class CallNumUtils {
     /**
      * return the string between the LC class number and the cutter, if it
      *  starts with a digit, null otherwise
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *  
+     * @param rawLCcallnum  the entire LC call number, as a string
+     * @return              string between class number and cutter
      */
     public static String getLCClassSuffix(String rawLCcallnum) {
         String result = null;
@@ -293,7 +315,9 @@ public final class CallNumUtils {
      * return the first cutter in the LC call number, without the preceding
      * characters (such as the "required" period, which is sometimes missing,
      * or spaces), or any suffixes
-     * @param rawCallnum - the entire call number, as a string
+     * 
+     * @param rawCallnum  the entire call number, as a string
+     * @return            first cutter
      */
     public static String getFirstLCcutter(String rawCallnum) {
         String result = null;
@@ -324,7 +348,9 @@ public final class CallNumUtils {
     /**
      * return the suffix after the first cutter, if there is one.  This occurs
      *  before the second cutter, if there is one.
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *  
+     * @param rawLCcallnum  the entire LC call number, as a string
+     * @return              first cutter suffix
      */
     public static String getFirstLCcutterSuffix(String rawLCcallnum) {
         String result = null;
@@ -387,7 +413,9 @@ public final class CallNumUtils {
      * return the second cutter in the call number, without the preceding
      * characters (such as the "required" period, which is sometimes missing,
      * or spaces), or any suffixes
-     * @param rawLCcallnum - the entire call number, as a string
+     * 
+     * @param rawLCcallnum  the entire call number, as a string
+     * @return              second cutter
      */
     public static String getSecondLCcutter(String rawLCcallnum) {
         String result = null;
@@ -428,9 +456,11 @@ public final class CallNumUtils {
     }
 
     /**
-     * return the suffix after the first cutter, if there is one.  This occurs
+     * return the suffix after the second cutter, if there is one.  This occurs
      *  before the second cutter, if there is one.
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *  
+     * @param rawLCcallnum  the entire LC call number, as a string
+     * @return              second cutter suffix
      */
     public static String getSecondLCcutterSuffix(String rawLCcallnum) {
         String result = null;
@@ -447,9 +477,11 @@ public final class CallNumUtils {
     }
 
     /**
-     * return the suffix after the first cutter, if there is one.  This occurs
+     * return the year suffix after the second cutter, if there is one.  This occurs
      *  before the second cutter, if there is one.
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *  
+     * @param rawLCcallnum  the entire LC call number, as a string
+     * @return              year suffix 
      * @deprecated
      */
 // do we want to separate out year suffixes?  for all or just here? - unused
@@ -488,6 +520,9 @@ public final class CallNumUtils {
     /**
      * return the portion of the Dewey call number string that occurs before the
      *  Cutter.
+     *  
+     *  @param callnum  call number
+     *  @return         portion before cutter
      */
     public static final String getDeweyB4Cutter(String callnum) {
         String result = null;
@@ -505,7 +540,9 @@ public final class CallNumUtils {
      * return the first cutter in the call number, without the preceding
      * characters (such as the "required" period, which is sometimes missing,
      * or spaces).
-     * @param rawCallnum - the entire call number, as a string
+     * 
+     * @param rawCallnum  the entire call number, as a string
+     * @return            first cutter
      */
     public static String getDeweyCutter(String rawCallnum) {
         String result = null;
@@ -573,7 +610,9 @@ public final class CallNumUtils {
 
     /**
      * return suffix to the first cutter in the dewey call number
-     * @param rawCallnum - the entire call number, as a string
+     * 
+     * @param rawCallnum  the entire call number, as a string
+     * @return            first cutter
      */
     public static String getDeweyCutterSuffix(String rawCallnum) {
         if (rawCallnum == null || rawCallnum.length() == 0)
@@ -651,8 +690,8 @@ public final class CallNumUtils {
      * Remove leading and trailing whitespace, ensure whitespace is always a
      *  single space, remove spaces after periods, remove trailing periods
      *
-     * @param rawCallnum - a non-null String containing a Dewey call number
-     * @return normalized form of a call number
+     * @param rawCallnum  a non-null String containing a Dewey call number
+     * @return            normalized form of a call number
      */
     public static String normalizeCallnum(String rawCallnum) {
 
@@ -676,6 +715,9 @@ public final class CallNumUtils {
     /**
      * reduce multiple whitespace to single, remove spaces before or after
      *   periods, remove spaces between letters and class digits
+     *   
+     * @param rawCallnum  the entire call number, as a string
+     * @return            normalized form of the input
      */
     static String normalizeLCcallnum(String rawLCcallnum)
     {
@@ -697,6 +739,10 @@ public final class CallNumUtils {
     /**
      * given a raw LC call number, return the shelf key - a sortable version
      *  of the call number
+     *  
+     *  @param rawLCcallnum  the entire call number, as a string
+     *  @param recid         record id (unused)
+     *  @return              sortable shelf key
      */
     public static String getLCShelfkey(String rawLCcallnum, String recid) {
         StringBuilder resultBuf = new StringBuilder();
@@ -775,6 +821,10 @@ public final class CallNumUtils {
     /**
      * normalize the cutter string for shelf list sorting - make number into
      *  decimal of the number of digits indicated by param
+     *  
+     *  @param cutter
+     *  @param numDigits
+     *  @return          sortable cutter
      */
     private static String normalizeCutter(String cutter, int numDigits) {
         String result = null;
@@ -802,7 +852,10 @@ public final class CallNumUtils {
 
     /**
      * normalize a suffix for shelf list sorting by changing all digit
-     *  substrings to a constant length (left padding with zeros).
+     * substrings to a constant length (left padding with zeros).
+     * 
+     * @param suffix call number suffix
+     * @return       normalized form
      */
     public static String normalizeSuffix(String suffix) {
         if (suffix != null && suffix.length() > 0) {
@@ -840,6 +893,9 @@ public final class CallNumUtils {
      * given a shelfkey (a lexicaly sortable call number), return the reverse
      * shelf key - a sortable version of the call number that will give the
      * reverse order (for getting "previous" call numbers in a list)
+     * 
+     * @param shelfkey  forward-sortable shelfkey
+     * @return          reverse-sortable shelfkey
      */
     public static String getReverseShelfKey(String shelfkey) {
         StringBuilder resultBuf = new StringBuilder(reverseDefault);
@@ -850,7 +906,10 @@ public final class CallNumUtils {
 
     /**
      * return the reverse String value, mapping A --> 9, B --> 8, ...
-     *   9 --> A and also non-alphanum to sort properly (before or after alphanum)
+     * 9 --> A and also non-alphanum to sort properly (before or after alphanum)
+     * 
+     * @param orig  original string
+     * @return      reversed string
      */
     static String reverseAlphanum(String orig) {
 
@@ -912,7 +971,10 @@ public final class CallNumUtils {
 
     /**
      * for non alpha numeric characters, return a character that will sort
-     *  first or last, whichever is the opposite of the original character.
+     * first or last, whichever is the opposite of the original character.
+     * 
+     * @param ch  original character
+     * @return    character that sorts opposite of input
      */
     public static char[] reverseNonAlphanum(char ch) {
         // use punctuation before or after alphanum as appropriate
@@ -935,7 +997,10 @@ public final class CallNumUtils {
 
     /**
      * given a raw Dewey call number, return the shelf key - a sortable
-     *  version of the call number
+     * version of the call number
+     * 
+     * @param rawDeweyCallnum  call number
+     * @return                 shelfkey
      */
     public static String getDeweyShelfKey(String rawDeweyCallnum) {
         StringBuilder resultBuf = new StringBuilder();
@@ -970,9 +1035,10 @@ public final class CallNumUtils {
 
     /**
      * normalizes numbers (can have decimal portion) to (digitsB4) before
-     *  the decimal (adding leading zeroes as necessary) and (digitsAfter
-     *  after the decimal.  In the case of a whole number, there will be no
-     *  decimal point.
+     * the decimal (adding leading zeroes as necessary) and (digitsAfter
+     * after the decimal.  In the case of a whole number, there will be no
+     * decimal point.
+     * 
      * @param floatStr    the number, as a String
      * @param digitsB4    the number of characters the result should have before the
      *                    decimal point (leading zeroes will be added as necessary). A negative
@@ -981,6 +1047,7 @@ public final class CallNumUtils {
      *                    the decimal point.  A negative number means leave whatever fraction
      *                    encountered as is; don't pad with trailing zeroes (trailing zeroes in
      *                    this case will be removed)
+     * @return            normalized number
      * @throws NumberFormatException if string can't be parsed as a number
      */
     public static String normalizeFloat(String floatStr, int digitsB4, int digitsAfter)
@@ -1010,10 +1077,11 @@ public final class CallNumUtils {
 
     /**
      * remove volume information from LC call number if it is present as a
-     *   suffix
-     * @param rawLCcallnum
-     * @return call number without the volume information, or full call number
-     *   if no volume information was present.
+     * suffix
+     *   
+     * @param rawLCcallnum call number
+     * @return             call number without the volume information, or full call 
+     *                     number if no volume information was present.
      */
     public static String removeLCVolSuffix(String rawLCcallnum)
     {
@@ -1060,10 +1128,11 @@ public final class CallNumUtils {
 
     /**
      * remove volume information from Dewey call number if it is present as a
-     *   suffix
-     * @param rawDeweyCallnum
-     * @return call number without the volume information, or full call number
-     *   if no volume information was present.
+     * suffix
+     * 
+     * @param rawDeweyCallnum  call number
+     * @return                 call number without the volume information, or full
+     *                         call number if no volume information was present.
      */
     public static String removeDeweyVolSuffix(String rawDeweyCallnum)
     {
@@ -1093,8 +1162,9 @@ public final class CallNumUtils {
 
     /**
      * adds leading zeros to a dewey call number, when they're missing.
-     * @param deweyCallNum
-     * @return the dewey call number with leading zeros
+     * 
+     * @param deweyCallNum call number
+     * @return             the dewey call number with leading zeros
      */
     public static String addLeadingZeros(String deweyCallNum)
     {
@@ -1127,9 +1197,13 @@ public final class CallNumUtils {
 
     /**
      * return a format string corresponding to the number of digits specified
-     * @param numDigits - the number of characters the result should have (to be padded
-     *  with zeroes as necessary). A negative number means leave whatever digits
-     *   encountered as is; don't pad with zeroes -- up to 12 characters.
+     * 
+     * @param numDigits  the number of characters the result should have (to be
+     *  
+     *                   padded with zeroes as necessary). A negative number 
+     *                   means leave whatever digits encountered as is; don't
+     *                   pad with zeroes -- up to 12 characters.
+     * @return           format string
      */
     private static String getFormatString(int numDigits) {
         StringBuilder b4 = new StringBuilder();

--- a/src/org/solrmarc/callnum/CallNumUtils.java
+++ b/src/org/solrmarc/callnum/CallNumUtils.java
@@ -740,9 +740,9 @@ public final class CallNumUtils {
      * given a raw LC call number, return the shelf key - a sortable version
      *  of the call number
      *  
-     *  @param rawLCcallnum  the entire call number, as a string
-     *  @param recid         record id (unused)
-     *  @return              sortable shelf key
+     * @param rawLCcallnum  the entire call number, as a string
+     * @param recid         record id (unused)
+     * @return              sortable shelf key
      */
     public static String getLCShelfkey(String rawLCcallnum, String recid) {
         StringBuilder resultBuf = new StringBuilder();

--- a/src/org/solrmarc/callnum/DeweyCallNumber.java
+++ b/src/org/solrmarc/callnum/DeweyCallNumber.java
@@ -216,6 +216,8 @@ public class DeweyCallNumber extends AbstractCallNumber {
      * Returns a normal form of the classification string.
      * 
      * <p>Supplies any missing leading zeroes.
+     * 
+     * @return classification string
      */
     public String getClassificationNormalized() {
         if (classDigits == null || classDigits.length() >= 3) {

--- a/src/org/solrmarc/debug/SolrMarcDebug.java
+++ b/src/org/solrmarc/debug/SolrMarcDebug.java
@@ -84,6 +84,8 @@ public class SolrMarcDebug extends BootableMain
     static int[] fontSizeArray = { 8, 10, 12, 14, 18, 22, 28, 36, 42 };
     /**
      * Launch the application.
+     *
+     * @param args command line arguments
      */
     public static void main(final String[] args)
     {
@@ -107,6 +109,8 @@ public class SolrMarcDebug extends BootableMain
 
     /**
      * Create the application.
+     *
+     * @param args command line arguments
      */
     public SolrMarcDebug(String args[])
     {

--- a/src/org/solrmarc/driver/Boot.java
+++ b/src/org/solrmarc/driver/Boot.java
@@ -77,6 +77,9 @@ public class Boot extends URLClassLoader
 
     /**
      * Classloader Methods - Implements a child-first delegation model to load classes needed by SolrMarc
+     *
+     * @param urls    the URLs from which to load classes and resources
+     * @param parent  the parent class loader for delegation
      */
     public Boot(URL[] urls, ClassLoader parent)
     {
@@ -184,8 +187,8 @@ public class Boot extends URLClassLoader
     */
 
     /**
-     * @param classname
-     * @param otherArgs
+     * @param classname  name of class to invoke
+     * @param otherArgs  args for main method
      */
     public static void invokeMain(String classname, String[] otherArgs)
     {
@@ -352,7 +355,7 @@ public class Boot extends URLClassLoader
     /**
      * Finds directory "lib" relative to the defaultHomeDir and loads all of
      * the jar files in that directory dynamically.  If it doesn't find a jar
-     * named marc4j*.jar it will log a fatal error and exit the program.
+     * named {@code marc4j*.jar} it will log a fatal error and exit the program.
      */
     private static void addLibDirJarstoClassPath()
     {
@@ -419,7 +422,11 @@ public class Boot extends URLClassLoader
     }
 
     /**
-     *  If using a custom classloader, use that to lookup and load the requested class by name
+     * If using a custom classloader, use that to lookup and load the requested class by name
+     *
+     * @param classname                name of class to look up
+     * @return                         class that was named
+     * @throws ClassNotFoundException  if class was not found by loader
      */
     public static Class<?>classForName(String classname) throws ClassNotFoundException
     {
@@ -563,8 +570,8 @@ public class Boot extends URLClassLoader
      *  in the parent directory of the provided directory for a jar with
      *  a name containing "solrj"
      *
-     * @param homeDirStrs
-     * @param dir
+     * @param homeDirStrs  home directory strings
+     * @param dir          directory
      */
     public static void extendClasspathWithSolJJarDir(String[] homeDirStrs, File dir)
     {

--- a/src/org/solrmarc/driver/ChunkIndexerWorker.java
+++ b/src/org/solrmarc/driver/ChunkIndexerWorker.java
@@ -16,15 +16,16 @@ import org.marc4j.marc.Record;
  *  This class implements sending batches of documents to Solr.  It implements retries to cope with
  *  the issue where one bad document in a batch will cause all subsequent solr input documents in
  *  the batch to be skipped.
- *  <br/>
+ *  <p>
  *  To accomplish this the class will divide the batch into several smaller segments, and re-try sending
  *  those smaller batches.   Eventually a sub-batch containing the problem record will be sent one-by-one
  *  to insure that all valid documents are correctly sent to Solr, while only the documents containing
  *  errors are skipped.
- *  <br/>
+ *  </p>
+ *  <p>
  *  If the parameter errQ is not null the records that cause an error will be appended to that list and
  *  can subsequently be logged or fixed and retried.
- *
+ *  </p>
  *
  * @author rh9ec
  *

--- a/src/org/solrmarc/driver/Indexer.java
+++ b/src/org/solrmarc/driver/Indexer.java
@@ -97,9 +97,9 @@ public class Indexer
      * sends that document to solr This is the single threaded version that does
      * each of those action sequentially
      *
-     * @param reader
-     * @return array containing number of records read, number of records
-     *         indexed, and number of records sent to solr
+     * @param reader  MARC record reader object
+     * @return        array containing number of records read, number of records
+     *                indexed, and number of records sent to solr
      */
     public int[] indexToSolr(final MarcReader reader)
     {

--- a/src/org/solrmarc/index/SolrIndexer.java
+++ b/src/org/solrmarc/index/SolrIndexer.java
@@ -219,15 +219,11 @@ public class SolrIndexer implements Mixin
      * instance of each marc field will be put in a separate result (but the
      * subfields will be concatenated into a single value for each marc field)
      *
-     * @param record
-     *            marc record object
-     * @param fieldSpec -
-     *            the desired marc fields and subfields as given in the
-     *            xxx_index.properties file
-     * @param separator -
-     *            the character to use between subfield values in the solr field
-     *            contents
-     * @return Set of values (as strings) for solr field
+     * @param record        marc record object
+     * @param fieldSpec     the desired marc fields and subfields as given in the
+     *                      xxx_index.properties file
+     * @param firstAllJoin  subfields to join to all alphas
+     * @return              Set of values (as strings) for solr field
      */
     public Set<String> getAllAlphaSubfields(final Record record, String fieldSpec, String firstAllJoin)
     {
@@ -324,7 +320,7 @@ public class SolrIndexer implements Mixin
      *         and with non-filing characters omitted. Null returned if no
      *         title can be found.
      *
-     * @see SolrIndexerShim#getTitle
+     * @see SolrIndexerShim#getSortableTitle
      */
     public String getSortableTitle(Record record)
     {

--- a/src/org/solrmarc/index/SolrIndexerShim.java
+++ b/src/org/solrmarc/index/SolrIndexerShim.java
@@ -156,7 +156,7 @@ public class SolrIndexerShim
      * tagStr that is NOT about bytes (i.e. not a 008[7-12] type fieldspec), the
      * result string is the concatenation of all the specific subfields.
      *
-     * @param record -
+     * @param record
      *            the marc record object
      * @param tagStr
      *            string containing which field(s)/subfield(s) to use. This is a
@@ -172,7 +172,6 @@ public class SolrIndexerShim
      *            desired.
      * @return the contents of the indicated marc field(s)/subfield(s), as a set
      *         of Strings.
-     * @throws Exception
      */
 //    public Set<String> getFieldList(Record record, String tagStr)
 //    {
@@ -215,7 +214,6 @@ public class SolrIndexerShim
      *            bytes, NOT a pattern. 100abcd denotes subfields a, b, c, d are
      *            desired.
      * @return the contents of the indicated marc field(s)/subfield(s).
-     * @throws Exception
      */
     public List<String> getFieldListAsList(Record record, String tagStr)
     {
@@ -249,7 +247,6 @@ public class SolrIndexerShim
      *  e.g. 245) optionally followed by characters identifying which subfields
      *  to use.
      * @return first value of the indicated marc field(s)/subfield(s) as a string
-     * @throws Exception
      */
     public String getFirstFieldVal(Record record, String tagStr)
     {
@@ -309,11 +306,11 @@ public class SolrIndexerShim
     /**
      * Get the specified substring of subfield values from the specified MARC
      * field, returned as  a set of strings to become lucene document field values
-     * @param record - the marc record object
-     * @param fldTag - the field name, e.g. 008
-     * @param subfldStr - the string containing the desired subfields
-     * @param beginIx - the beginning index of the substring of the subfield value
-     * @param endIx - the ending index of the substring of the subfield value
+     * @param record     the marc record object
+     * @param fldTag     the field name, e.g. 008
+     * @param subfldStr  the string containing the desired subfields
+     * @param beginIx    the beginning index of the substring of the subfield value
+     * @param endIx      the ending index of the substring of the subfield value
      * @param collector  an object to accumulate the data indicated by <code>fldTag</code> and
      *                   <code>subfldsStr</code>.
      */
@@ -443,12 +440,11 @@ public class SolrIndexerShim
      *
      * @param record
      *            marc record object
-     * @param fieldSpec -
+     * @param fieldSpec
      *            the desired marc fields and subfields as given in the
      *            xxx_index.properties file
-     * @param separator -
-     *            the character to use between subfield values in the solr field
-     *            contents
+     * @param firstAllJoin
+     *            subfields to join to all alphas
      * @return Set of values (as strings) for solr field
      */
     public Set<String> getAllAlphaSubfields(final Record record, String fieldSpec, String firstAllJoin)
@@ -611,7 +607,7 @@ public class SolrIndexerShim
      *         and with non-filing characters omitted. Null returned if no
      *         title can be found.
      *
-     * @see SolrIndexerShim#getTitle
+     * @see SolrIndexerShim#getFieldListCollector
      */
     public String getSortableTitle(Record record)
     {

--- a/src/org/solrmarc/index/extractor/impl/java/JavaValueExtractorUtils.java
+++ b/src/org/solrmarc/index/extractor/impl/java/JavaValueExtractorUtils.java
@@ -48,10 +48,9 @@ public class JavaValueExtractorUtils
 
     /**
      * Compiles java sources if they have changed.
-     * @param homeDirStrs
      *
-     * @return true if one or more java sources were compiled, else false.
-     * @throws IOException
+     * @param recompileAll  recompile flag
+     * @return              true if one or more java sources were compiled, else false.
      */
     public boolean compileSources(boolean recompileAll)
     {

--- a/src/org/solrmarc/index/extractor/impl/patternMapping/PatternMapping.java
+++ b/src/org/solrmarc/index/extractor/impl/patternMapping/PatternMapping.java
@@ -113,9 +113,8 @@ public class PatternMapping
      * PatternMapping#canHandle(String) has to be called before. Otherwise the
      * result will not be correct!
      *
-     * @param value
-     *            the value to be mapped.
-     * @return the mapped value.
+     * @param inputMatcher  regex matcher.
+     * @return              the mapped value.
      */
     public String map(final Matcher inputMatcher)
     {
@@ -134,9 +133,8 @@ public class PatternMapping
      * PatternMapping#canHandle(String) has to be called before. Otherwise the
      * result will not be correct!
      *
-     * @param value
-     *            the value to be mapped.
-     * @return the mapped value.
+     * @param inputMatcher  regex matcher.
+     * @return              the mapped value.
      */
     public String filter(final Matcher inputMatcher)
     {

--- a/src/org/solrmarc/index/extractor/methodcall/AbstractExtractorMethodCall.java
+++ b/src/org/solrmarc/index/extractor/methodcall/AbstractExtractorMethodCall.java
@@ -26,6 +26,8 @@ public abstract class AbstractExtractorMethodCall<T> implements ExternalMethod
      * @param parameters
      *            the parameters of this call.
      * @return the return value of this call.
+     * @throws Exception
+     *            in case of error
      */
     public T invoke(final Record record, final Object[] parameters) throws Exception
     {

--- a/src/org/solrmarc/index/extractor/methodcall/AbstractMappingMethodCall.java
+++ b/src/org/solrmarc/index/extractor/methodcall/AbstractMappingMethodCall.java
@@ -14,11 +14,13 @@ public abstract class AbstractMappingMethodCall<T>
     /**
      * The parameters[0] will be overridden with the record!
      *
-     * @param record
+     * @param incoming
      *            current record
      * @param parameters
      *            the parameters of this call.
      * @return the return value of this call.
+     * @throws Exception
+     *            in case of error
      */
     public T invoke(final T incoming, final Object[] parameters) throws Exception
     {
@@ -26,6 +28,12 @@ public abstract class AbstractMappingMethodCall<T>
         return invoke(parameters);
     }
 
+    /**
+     *
+     * @param parameters  the parameters of this call
+     * @return            the value of this call
+     * @throws Exception  when runtime error
+     */
     public abstract T invoke(final Object[] parameters) throws Exception;
 
     public String getObjectName()

--- a/src/org/solrmarc/index/indexer/ValueIndexerFactory.java
+++ b/src/org/solrmarc/index/indexer/ValueIndexerFactory.java
@@ -139,7 +139,7 @@ public class ValueIndexerFactory
     /**
      * Return ALL of the exceptions encountered while processing indexing specification
      *
-     * @return
+     * @return list of validation exceptions
      */
     public List<IndexerSpecException> getValidationExceptions()
     {
@@ -147,9 +147,9 @@ public class ValueIndexerFactory
     }
 
     /**
-     * Return ALL of the exceptions encountered while processing indexing specification
+     * Add an error to list of exceptions for the current record
      *
-     * @return
+     * @param error  error to add
      */
     public void addPerRecordError(IndexerSpecException error)
     {
@@ -169,7 +169,7 @@ public class ValueIndexerFactory
     /**
      * Return the value defined as the default class name to use when resolving multiple matches for the same custom method
      *
-     * @return
+     * @return default class name
      */
     public String getDefaultCustomClassname()
     {
@@ -179,7 +179,7 @@ public class ValueIndexerFactory
     /**
      * Return the extractor factories loaded above for use in the CUP parser
      *
-     * @return
+     * @return list of extractor factories
      */
     final List<AbstractValueExtractorFactory> getExtractorFactories()
     {
@@ -189,13 +189,16 @@ public class ValueIndexerFactory
     /**
      * Return ALL of the exceptions encountered while processing indexing specification
      *
-     * @return
+     * @return exceptions
      */
     public Set<IndexerSpecException> getPerRecordErrors()
     {
         return perRecordExceptions.get();
     }
 
+    /**
+     * Clear any stored exceptions encountered while processing indexing specification
+     */
     public void clearPerRecordErrors()
     {
         perRecordExceptions.get().clear();

--- a/src/org/solrmarc/marc/MarcFilteredReader.java
+++ b/src/org/solrmarc/marc/MarcFilteredReader.java
@@ -61,10 +61,14 @@ public class MarcFilteredReader implements MarcReader
     static Logger logger = Logger.getLogger(MarcFilteredReader.class.getName());
     
     /**
-     * 
-     * @param r
-     * @param ifFieldPresent
-     * @param ifFieldMissing
+     *
+     * @param r                MARC reader
+     * @param ifFieldPresent   include record if field is present
+     * @param ifFieldMissing   include record if field is not present
+     * @param deleteSubfields  fieldspec for subfields to delete from the records,
+     *                         only supports fieldspecs that list tag and up to one
+     *                         subfield, see implementation of
+     *                         {@link MarcFilteredReader#deleteSubfields(Record)}
      */
     public MarcFilteredReader(MarcReader r, String ifFieldPresent, String ifFieldMissing, String deleteSubfields)
     {

--- a/src/org/solrmarc/solr/SolrProxy.java
+++ b/src/org/solrmarc/solr/SolrProxy.java
@@ -12,6 +12,9 @@ public abstract class SolrProxy
 {
     /**
      * return true if exception is a SolrException
+     *
+     * @param e  exception to check
+     * @return   true if exception is a SolrException
      */
     public final boolean isSolrException(Exception e)
     {
@@ -23,9 +26,8 @@ public abstract class SolrProxy
     /**
      * given a SolrInputDocument add it to the index
      * 
-     * @param fieldsMap
-     *            - map of field names and values to add to the document
-     * @return a string representation of the document
+     * @param document  document to add to Solr index
+     * @return          a string representation of the document
      */
 
     public abstract int addDoc(SolrInputDocument document);
@@ -42,6 +44,8 @@ public abstract class SolrProxy
 
     /**
      * commit changes to the index
+     *
+     * @param optimize  Solr run database post-commit
      */
     public abstract void commit(boolean optimize);
 

--- a/src/org/solrmarc/tools/CallNumUtils.java
+++ b/src/org/solrmarc/tools/CallNumUtils.java
@@ -39,6 +39,9 @@ public final class CallNumUtils
     /**
      * given a possible Library of Congress call number value, determine if it
      *  matches the pattern of an LC call number
+     *
+     * @param possLCval  possible call number to check
+     * @return           true if parses as a valid LC call number
      */
     public static final boolean isValidLC(String possLCval)
     {
@@ -48,6 +51,9 @@ public final class CallNumUtils
     /**
      * given a possible Dewey call number value, determine if it
      *  matches the pattern of an Dewey call number
+     *
+     * @param possDeweyVal  possible call number to check
+     * @return              true if parses as a valid Dewey call number with a cutter
      */
     public static final boolean isValidDeweyWithCutter(String possDeweyVal)
     {
@@ -55,9 +61,12 @@ public final class CallNumUtils
     }
 
     /**
-      * given a possible Dewey call number value, determine if it
-      *  matches the pattern of an Dewey call number
-      */
+     * given a possible Dewey call number value, determine if it
+     *  matches the pattern of an Dewey call number
+     *
+     * @param possDeweyVal  possible call number to check
+     * @return              true if parses as a valid Dewey call number
+     */
     public static final boolean isValidDewey(String possDeweyVal)
     {
         return org.solrmarc.callnum.CallNumUtils.isValidDewey(possDeweyVal);
@@ -66,6 +75,9 @@ public final class CallNumUtils
     /**
      * return the portion of the call number string that occurs before the
      *  Cutter, NOT including any class suffixes occuring before the cutter
+     *
+     * @param callnum  call number to parse
+     * @return         the part of the call number before the cutter
      */
     public static final String getPortionBeforeCutter(String callnum)
     {
@@ -75,6 +87,9 @@ public final class CallNumUtils
     /**
      * return the portion of the LC call number string that occurs before the
      *  Cutter.
+     *
+     * @param callnum  LC call number to parse
+     * @return         the part of the LC call number before the first cutter
      */
     public static final String getLCB4FirstCutter(String callnum)
     {
@@ -84,6 +99,9 @@ public final class CallNumUtils
     /**
      * Given a raw LC call number, return the initial letters (before any
      *  numbers)
+     *
+     * @param rawLCcallnum  LC call number to parse
+     * @return              the initial letters of the LC classification
      */
     public static String getLCstartLetters(String rawLCcallnum)
     {
@@ -94,7 +112,9 @@ public final class CallNumUtils
      * return the numeric portion of the required portion of the LC classification.
      *  LC classification requires
      *    1-3 capital letters followed by  float number (may be an integer)
-     * @param rawLCcallnum
+     *
+     * @param rawLCcallnum the entire LC call number, as a string
+     * @return             the numeric portion of the classification
      */
     public static String getLCClassDigits(String rawLCcallnum)
     {
@@ -104,7 +124,10 @@ public final class CallNumUtils
     /**
      * return the string between the LC class number and the cutter, if it
      *  starts with a digit, null otherwise
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *
+     * @param rawLCcallnum the entire LC call number, as a string
+     * @return             the portion of the string between the classification
+     *                     number and the cutter, or null if there is none.
      */
     public static String getLCClassSuffix(String rawLCcallnum)
     {
@@ -115,17 +138,21 @@ public final class CallNumUtils
      * return the first cutter in the LC call number, without the preceding
      * characters (such as the "required" period, which is sometimes missing,
      * or spaces), or any suffixes
-     * @param rawCallnum - the entire call number, as a string
+     *
+     * @param rawLCcallnum the entire LC call number, as a string
+     * @return             the first cutter of the call number without any suffix
      */
-    public static String getFirstLCcutter(String rawCallnum)
+    public static String getFirstLCcutter(String rawLCcallnum)
     {
-        return org.solrmarc.callnum.CallNumUtils.getFirstLCcutter(rawCallnum);
+        return org.solrmarc.callnum.CallNumUtils.getFirstLCcutter(rawLCcallnum);
     }
 
     /**
      * return the suffix after the first cutter, if there is one.  This occurs
      *  before the second cutter, if there is one.
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *
+     * @param rawLCcallnum the entire LC call number, as a string
+     * @return             the suffix of the first cutter of the call number
      */
     public static String getFirstLCcutterSuffix(String rawLCcallnum)
     {
@@ -136,7 +163,9 @@ public final class CallNumUtils
      * return the second cutter in the call number, without the preceding
      * characters (such as the "required" period, which is sometimes missing,
      * or spaces), or any suffixes
-     * @param rawLCcallnum - the entire call number, as a string
+     *
+     * @param rawLCcallnum the entire LC call number, as a string
+     * @return             the second cutter of the call number without any suffix
      */
     public static String getSecondLCcutter(String rawLCcallnum)
     {
@@ -144,9 +173,11 @@ public final class CallNumUtils
     }
 
     /**
-     * return the suffix after the first cutter, if there is one.  This occurs
+     * return the suffix after the second cutter, if there is one.  This occurs
      *  before the second cutter, if there is one.
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *
+     * @param rawLCcallnum the entire LC call number, as a string
+     * @return             the suffix of the second cutter of the call number
      */
     public static String getSecondLCcutterSuffix(String rawLCcallnum)
     {
@@ -154,9 +185,11 @@ public final class CallNumUtils
     }
 
     /**
-     * return the suffix after the first cutter, if there is one.  This occurs
+     * return the suffix after the second cutter, if there is one.  This occurs
      *  before the second cutter, if there is one.
-     * @param rawLCcallnum - the entire LC call number, as a string
+     *
+     * @param rawLCcallnum the entire LC call number, as a string
+     * @return             the year suffix of the second cutter of the call number
      * @deprecated
      */
 // do we want to separate out year suffixes?  for all or just here? - unused
@@ -168,6 +201,9 @@ public final class CallNumUtils
     /**
      * return the portion of the Dewey call number string that occurs before the
      *  Cutter.
+     *
+     * @param callnum  call number to parse
+     * @return         the part of the call number before the cutter
      */
     public static final String getDeweyB4Cutter(String callnum)
     {
@@ -178,7 +214,9 @@ public final class CallNumUtils
      * return the first cutter in the call number, without the preceding
      * characters (such as the "required" period, which is sometimes missing,
      * or spaces).
-     * @param rawCallnum - the entire call number, as a string
+     *
+     * @param rawCallnum  the entire call number, as a string
+     * @return            the cutter of the input call number
      */
     public static String getDeweyCutter(String rawCallnum)
     {
@@ -187,7 +225,9 @@ public final class CallNumUtils
 
     /**
      * return suffix to the first cutter in the dewey call number
-     * @param rawCallnum - the entire call number, as a string
+     *
+     * @param rawCallnum  the entire call number, as a string
+     * @return            the suffix of the first cutter of the input call number
      */
     public static String getDeweyCutterSuffix(String rawCallnum)
     {
@@ -200,8 +240,8 @@ public final class CallNumUtils
      * Remove leading and trailing whitespace, ensure whitespace is always a
      *  single space, remove spaces after periods, remove trailing periods
      *
-     * @param rawCallnum - a non-null String containing a Dewey call number
-     * @return normalized form of a call number
+     * @param rawCallnum  a non-null String containing a Dewey call number
+     * @return            the normalized form of the call number
      */
     public static String normalizeCallnum(String rawCallnum)
     {
@@ -211,6 +251,10 @@ public final class CallNumUtils
     /**
      * given a raw LC call number, return the shelf key - a sortable version
      *  of the call number
+     *
+     * @param rawLCcallnum  a non-null String containing an LC call number
+     * @param recid         record id (unused)
+     * @return              the normalized form of the call number
      */
     public static String getLCShelfkey(String rawLCcallnum, String recid)
     {
@@ -220,6 +264,9 @@ public final class CallNumUtils
     /**
      * normalize a suffix for shelf list sorting by changing all digit
      *  substrings to a constant length (left padding with zeros).
+     *
+     * @param suffix  the suffix of a call number
+     * @return        the suffix normalized for sorting, left-padded with zeros)
      */
     public static String normalizeSuffix(String suffix)
     {
@@ -230,6 +277,10 @@ public final class CallNumUtils
      * given a shelfkey (a lexicaly sortable call number), return the reverse
      * shelf key - a sortable version of the call number that will give the
      * reverse order (for getting "previous" call numbers in a list)
+     *
+     * @param shelfkey  the forward-sortable shelfkey that has been computed for a
+     *                  call number
+     * @return          a reverse-order version of the shelfkey
      */
     public static String getReverseShelfKey(String shelfkey)
     {
@@ -240,6 +291,9 @@ public final class CallNumUtils
     /**
      * for non alpha numeric characters, return a character that will sort
      *  first or last, whichever is the opposite of the original character.
+     *
+     * @param ch  original character
+     * @return    character that sorts opposite of input
      */
     public static char[] reverseNonAlphanum(char ch)
     {
@@ -249,6 +303,9 @@ public final class CallNumUtils
     /**
      * given a raw Dewey call number, return the shelf key - a sortable
      *  version of the call number
+     *
+     * @param rawDeweyCallnum  call number
+     * @return                 shelfkey
      */
     public static String getDeweyShelfKey(String rawDeweyCallnum)
     {
@@ -261,6 +318,7 @@ public final class CallNumUtils
      *  the decimal (adding leading zeroes as necessary) and (digitsAfter
      *  after the decimal.  In the case of a whole number, there will be no
      *  decimal point.
+     *
      * @param floatStr    the number, as a String
      * @param digitsB4    the number of characters the result should have before the
      *                    decimal point (leading zeroes will be added as necessary). A negative
@@ -269,6 +327,7 @@ public final class CallNumUtils
      *                    the decimal point.  A negative number means leave whatever fraction
      *                    encountered as is; don't pad with trailing zeroes (trailing zeroes in
      *                    this case will be removed)
+     * @return            normalized number
      * @throws NumberFormatException if string can't be parsed as a number
      */
     public static String normalizeFloat(String floatStr, int digitsB4, int digitsAfter)
@@ -279,9 +338,10 @@ public final class CallNumUtils
     /**
      * remove volume information from LC call number if it is present as a
      *   suffix
-     * @param rawLCcallnum
-     * @return call number without the volume information, or full call number
-     *   if no volume information was present.
+     *
+     * @param rawLCcallnum call number
+     * @return             call number without the volume information, or full call 
+     *                     number if no volume information was present.
      */
     public static String removeLCVolSuffix(String rawLCcallnum)
     {
@@ -292,9 +352,10 @@ public final class CallNumUtils
     /**
      * remove volume information from Dewey call number if it is present as a
      *   suffix
-     * @param rawDeweyCallnum
-     * @return call number without the volume information, or full call number
-     *   if no volume information was present.
+     *
+     * @param rawDeweyCallnum  call number
+     * @return                 call number without the volume information, or full
+     *                         call number if no volume information was present.
      */
     public static String removeDeweyVolSuffix(String rawDeweyCallnum)
     {
@@ -304,8 +365,9 @@ public final class CallNumUtils
 
     /**
      * adds leading zeros to a dewey call number, when they're missing.
-     * @param deweyCallNum
-     * @return the dewey call number with leading zeros
+     *
+     * @param deweyCallNum call number
+     * @return             the dewey call number with leading zeros
      */
     public static String addLeadingZeros(String deweyCallNum)
     {

--- a/src/org/solrmarc/tools/CallNumUtils.java
+++ b/src/org/solrmarc/tools/CallNumUtils.java
@@ -26,11 +26,12 @@ package org.solrmarc.tools;
  */
 
 @Deprecated
-public final class CallNumUtils {
+public final class CallNumUtils
+{
     /**
      * Default Constructor: private, so it can't be instantiated by other objects
      */
-    private CallNumUtils(){ }
+    private CallNumUtils() { }
 
 
 //------ public methods --------
@@ -53,10 +54,10 @@ public final class CallNumUtils {
         return org.solrmarc.callnum.CallNumUtils.isValidDeweyWithCutter(possDeweyVal);
     }
 
-   /**
-     * given a possible Dewey call number value, determine if it
-     *  matches the pattern of an Dewey call number
-     */
+    /**
+      * given a possible Dewey call number value, determine if it
+      *  matches the pattern of an Dewey call number
+      */
     public static final boolean isValidDewey(String possDeweyVal)
     {
         return org.solrmarc.callnum.CallNumUtils.isValidDewey(possDeweyVal);

--- a/src/org/solrmarc/tools/DataUtil.java
+++ b/src/org/solrmarc/tools/DataUtil.java
@@ -318,6 +318,9 @@ public class DataUtil
      * Remove single square bracket characters if they are the start and/or end
      * chars (matched or unmatched) and are the only square bracket chars in the
      * string.
+     *
+     * @param origStr  text string with possible enclosing brackets
+     * @return         a copy of the text string with the brackets removed
      */
     public static String removeOuterBrackets(String origStr)
     {

--- a/src/org/solrmarc/tools/PropertyUtils.java
+++ b/src/org/solrmarc/tools/PropertyUtils.java
@@ -97,6 +97,9 @@ public class PropertyUtils
      *            the directories to search for the properties file
      * @param propertyFileName
      *            name of the sought properties file
+     * @param showName
+     *            whether the name of the file/resource being read should be
+     *            shown.
      * @return Properties object
      */
     public static Properties loadProperties(String propertyPaths[], String propertyFileName, boolean showName)
@@ -111,6 +114,9 @@ public class PropertyUtils
      *            the directories to search for the properties file
      * @param propertyFileName
      *            name of the sought properties file
+     * @param filenameReturn
+     *            array where first element will be set to the full path of the
+     *            loaded file
      * @return Properties object
      */
     public static Properties loadProperties(String propertyPaths[], String propertyFileName, String filenameReturn[])
@@ -162,6 +168,12 @@ public class PropertyUtils
      * @param showName
      *            whether the name of the file/resource being read should be
      *            shown.
+     * @param filenameProperty
+     *            the name of a property in which to store the name of the loaded
+     *            property file
+     * @param inputSourceReturn
+     *            array where first element will be set to the full path of the
+     *            loaded file
      * @return Properties object
      */
     public static Properties loadProperties(String propertyPaths[], String propertyFileName, boolean showName,
@@ -319,8 +331,9 @@ public class PropertyUtils
      * Takes an InputStream, reads the entire contents into a String
      * 
      * @param stream
-     *            - the stream to read in.
+     *            the stream to read in.
      * @return String containing entire contents of stream.
+     * @throws IOException  if there is an error reading the input stream
      */
     public static String readStreamIntoString(InputStream stream) throws IOException
     {


### PR DESCRIPTION
This PR adds an `ant` task to generate the javadoc for SolrMarc. It also fixes a large number of javadoc errors, given the stricter javadoc requirements introduced with Java 8.