### PR TITLE
Deprecated CallNumUtils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /src/org/solrmarc/index/indexer/FullConditionalParser.java
 
 /lib-solrj-5.5.0/
+
+.DS_Store

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,7 @@
 # TOP LEVEL solrmarc properties file
 java.compat.version = 1.7
 build.compiler = modern
+complier.args = -deprecation
 
 #specversion=3.0
 #implversion=4

--- a/build.xml
+++ b/build.xml
@@ -88,6 +88,7 @@
         <!-- Compile the java code from ${src} into ${build} -->
         <javac target="${java.compat.version}" source="${java.compat.version}" srcdir="${src.dir}" destdir="${build.dir}"
             includeantruntime="false" debug="true" debuglevel="lines,vars,source" updatedProperty="javac_compiled_some" encoding="UTF-8" >
+            <compilerarg value="${complier.args}"/>
             <classpath >
                 <fileset dir="${lib.dir}">
                     <include name="**/*.jar"/>
@@ -278,6 +279,7 @@
         <mkdir dir="${test.build.dir}" />
         <javac target="${java.compat.version}" source="${java.compat.version}" srcdir="${test.src.dir}" destdir="${test.build.dir}"
             includeantruntime="false" debug="true" debuglevel="lines,vars,source" encoding="UTF-8" >
+            <compilerarg value="${complier.args}"/>
             <classpath id="test.classpath">
                 <fileset dir="${dist.dir}">
                     <include name="${custom.jar.name}_${version}.jar"/>

--- a/src/org/solrmarc/callnum/CallNumUtils.java
+++ b/src/org/solrmarc/callnum/CallNumUtils.java
@@ -26,6 +26,7 @@ import java.util.regex.*;
  * @author Naomi Dushay, Stanford University
  */
 
+@Deprecated
 public final class CallNumUtils {
 
 

--- a/src/org/solrmarc/callnum/CallNumberMixin.java
+++ b/src/org/solrmarc/callnum/CallNumberMixin.java
@@ -18,7 +18,7 @@ public class CallNumberMixin implements Mixin
     {
         LCCallNumber callNum = new LCCallNumber(LCNum);
         String shelfKey = callNum.getShelfKey();
-        return(CallNumUtils.reverseAlphanum(shelfKey));
+        return(Utils.reverseAlphanum(shelfKey));
     }
     
     public static String LCCallNumberPaddedShelfKey(String LCNum)
@@ -31,7 +31,7 @@ public class CallNumberMixin implements Mixin
     {
         LCCallNumber callNum = new LCCallNumber(LCNum);
         String shelfKey = callNum.getPaddedShelfKey();
-        return(CallNumUtils.reverseAlphanum(shelfKey));
+        return(Utils.reverseAlphanum(shelfKey));
     }
     
     public static String DeweyCallNumberShelfKey(String DeweyNum)


### PR DESCRIPTION
Deprecated `CallNumUtils` class. Three methods were still in use by `CallNumberMixin`, these have been added to `org.solrmarc.callnum.Utils`.

This is in preparation to move the `org.solrmarc.callnum` package over to marc4j, wanting to leave behind the brittle aspects of `CallNumUtils`.