### PR TITLE
Make four-digit years more flexible; add tests.

### DIFF
--- a/src/org/solrmarc/tools/DataUtil.java
+++ b/src/org/solrmarc/tools/DataUtil.java
@@ -18,14 +18,15 @@ import org.solrmarc.index.extractor.formatter.FieldFormatter.eCleanVal;
 
 public class DataUtil
 {
+    private final static String TWO_DIGIT_PREFIXES = "(20|19|18|17|16|15|14|13|12|11|10)";
     private final static Pattern FOUR_DIGIT_PATTERN_BRACES = Pattern.compile("\\[[12]\\d{3,3}\\]");
     private final static Pattern FOUR_DIGIT_PATTERN_ONE_BRACE = Pattern.compile("\\[[12]\\d{3,3}");
     private final static Pattern FOUR_DIGIT_PATTERN_STARTING_WITH_1_2 = Pattern
-            .compile("(20|19|18|17|16|15)[0-9][0-9]");
+            .compile(TWO_DIGIT_PREFIXES + "[0-9][0-9]");
     private final static Pattern FOUR_DIGIT_PATTERN_OTHER_1 = Pattern.compile("l\\d{3,3}");
     private final static Pattern FOUR_DIGIT_PATTERN_OTHER_2 = Pattern.compile("\\[19\\]\\d{2,2}");
-    private final static Pattern FOUR_DIGIT_PATTERN_OTHER_3 = Pattern.compile("(20|19|18|17|16|15)[0-9][-?0-9]");
-    private final static Pattern FOUR_DIGIT_PATTERN_OTHER_4 = Pattern.compile("i.e. (20|19|18|17|16|15)[0-9][0-9]");
+    private final static Pattern FOUR_DIGIT_PATTERN_OTHER_3 = Pattern.compile(TWO_DIGIT_PREFIXES + "[0-9][-?0-9]");
+    private final static Pattern FOUR_DIGIT_PATTERN_OTHER_4 = Pattern.compile("i.e. " + TWO_DIGIT_PREFIXES+ "[0-9][0-9]");
     private final static Pattern BC_DATE_PATTERN = Pattern.compile("[0-9]+ [Bb][.]?[Cc][.]?");
     private final static Pattern FOUR_DIGIT_PATTERN = Pattern.compile("\\d{4,4}");
     protected static Logger logger = Logger.getLogger(DataUtil.class.getName());

--- a/test/src/org/solrmarc/index/UtilsTests.java
+++ b/test/src/org/solrmarc/index/UtilsTests.java
@@ -7,12 +7,25 @@ import org.solrmarc.tools.DataUtil;
 
 public class UtilsTests
 {
-
     @Test
     public void testCleanData()
     {
         assertEquals(DataUtil.cleanData("[ microfilm] :"), "microfilm");
         assertEquals(DataUtil.cleanData("Ray Parker Jr. :"), "Ray Parker Jr.");
+    }
+
+    @Test
+    public void testCleanDate()
+    {
+        assertEquals(DataUtil.cleanDate("197?"), "1970");
+        assertEquals(DataUtil.cleanDate("[19]72"), "1972");
+        assertEquals(DataUtil.cleanDate("1500"), "1500");
+        assertEquals(DataUtil.cleanDate("l500"), "1500"); // "L" instead of "1"
+        assertEquals(DataUtil.cleanDate("i.e. 1500"), "1500");
+        assertEquals(DataUtil.cleanDate("[2021]"), "2021");
+        assertEquals(DataUtil.cleanDate("[2021"), "2021");
+        assertNull(DataUtil.cleanDate("2000 B.C.")); // B.C. dates intentionally ignored
+        assertEquals(DataUtil.cleanDate("1400"), "1400");
     }
 
     @Test


### PR DESCRIPTION
This PR was opened in response to a [solrmarc-tech thread](https://groups.google.com/g/solrmarc-tech/c/mQBNnMDab-I) about date validation. SolrMarc currently arbitrarily ignores dates between 1000 and 1500 in some contexts but not others. This PR makes the date cleaning routine tolerant of all four-digit years up to 20xx and also adds a new test to exercise some of the date cleaning functionality.

I'd be happy for this to be merged as-is if no one objects to it, but I'm also open for further discussion and refinement as needed. I'm opening this just to get the ball rolling and so we don't forget about the issue with pre-1500 dates. The TODO list below captures some issues that may require further thought.

TODO:
- [ ] Discuss whether we need to account for three-digit years, and if so, how? Do we need zero-padding for instances using string-based sorting?
- [ ] Discuss whether this should be made configurable or extensible rather than being changed.