### PR TITLE
I think properties are to be UTF-8 and not ISO

### DIFF
--- a/src/org/solrmarc/tools/PropertyUtils.java
+++ b/src/org/solrmarc/tools/PropertyUtils.java
@@ -147,7 +147,7 @@ public class PropertyUtils
             }
             else
             {
-                props.load(in);
+                props.load(new InputStreamReader(in,"UTF-8"));
             }
             in.close();
         }
@@ -193,7 +193,7 @@ public class PropertyUtils
             }
             else
             {
-                props.load(in);
+                props.load(new InputStreamReader(in,"UTF-8"));
             }
             in.close();
             if (filenameProperty != null && inputStreamSource[0] != null)


### PR DESCRIPTION
Think it is better to read property files as UTF-8 than ISO. This works for my map files, so maybe it is of use here; Or at least for a discussion.