### PR TITLE
Fix Indexer exceptions when Solr id != controlnum

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -362,6 +362,7 @@
             </classpath>
             <sysproperty key="test.data.dir" path="${test.dir}/data" />
             <sysproperty key="log4j.debug" value="false" />
+            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/>
 
             <formatter type="plain"/>
 

--- a/src/org/solrmarc/driver/Indexer.java
+++ b/src/org/solrmarc/driver/Indexer.java
@@ -246,22 +246,24 @@ public class Indexer
         if (recDoc.getSolrMarcIndexerException() != null)
         {
             SolrMarcIndexerException smie = recDoc.getSolrMarcIndexerException();
-            String recCtrlNum = recDoc.rec.getControlNumber();
+            // Attempt to use a custom defined id value if available, then fall back to MARC control number
+            Object docIdObj = recDoc.doc.getFieldValue("id");
+            String docIdStr = (docIdObj != null) ? (String) docIdObj : recDoc.rec.getControlNumber();
             String idMessage = smie.getMessage() != null ? smie.getMessage() : "";
             if (smie.getLevel() == SolrMarcIndexerException.IGNORE)
             {
-                logger.info("Record will be Ignored " + (recCtrlNum != null ? recCtrlNum : "") + " " + idMessage + " (record count " + count + ")");
+                logger.info("Record will be Ignored " + (docIdStr != null ? docIdStr : "") + " " + idMessage + " (record count " + count + ")");
                 return(null);
             }
             else if (smie.getLevel() == SolrMarcIndexerException.DELETE)
             {
-                logger.info("Record will be Deleted " + (recCtrlNum != null ? recCtrlNum : "") + " " + idMessage + " (record count " + count + ")");
-                delQ.add(recCtrlNum);
+                logger.info("Record will be Deleted " + (docIdStr != null ? docIdStr : "") + " " + idMessage + " (record count " + count + ")");
+                delQ.add(docIdStr);
                 return(null);
             }
             else if (smie.getLevel() == SolrMarcIndexerException.EXIT)
             {
-                logger.info("Serious Error flagged in record " + (recCtrlNum != null ? recCtrlNum : "") + " " + idMessage + " (record count " + count + ")");
+                logger.info("Serious Error flagged in record " + (docIdStr != null ? docIdStr : "") + " " + idMessage + " (record count " + count + ")");
                 logger.info("Terminating indexing.");
                 throw new SolrMarcIndexerException(SolrMarcIndexerException.EXIT);
             }

--- a/test/data/records/jones_recs.xml
+++ b/test/data/records/jones_recs.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <marc:record xmlns:marc="http://www.loc.gov/MARC21/slim">
+    <marc:leader>03707cam a2200733 i 4500</marc:leader>
+    <marc:controlfield tag="001">in00006878693</marc:controlfield>
+    <marc:controlfield tag="003">OCoLC</marc:controlfield>
+    <marc:controlfield tag="005">20240913151450.4</marc:controlfield>
+    <marc:controlfield tag="008">240403t20242024nyu    e      000 f eng  </marc:controlfield>
+    <marc:datafield ind1="1" ind2="0" tag="245">
+      <marc:subfield code="a">I was a teenage slasher /</marc:subfield>
+      <marc:subfield code="c">Stephen Graham Jones.</marc:subfield>
+    </marc:datafield>
+    <marc:datafield ind1="f" ind2="f" tag="999">
+      <marc:subfield code="t">1</marc:subfield>
+    </marc:datafield>
+  </marc:record>
+  <marc:record xmlns:marc="http://www.loc.gov/MARC21/slim">
+    <marc:leader>03090cam a22005778i 4500</marc:leader>
+    <marc:controlfield tag="001">in00005570501</marc:controlfield>
+    <marc:controlfield tag="003">OCoLC</marc:controlfield>
+    <marc:controlfield tag="005">20220616144500.0</marc:controlfield>
+    <marc:controlfield tag="008">151106t20162016nyu           000 1 eng  </marc:controlfield>
+    <marc:datafield ind1="1" ind2="0" tag="245">
+      <marc:subfield code="a">Mongrels /</marc:subfield>
+      <marc:subfield code="c">Stephen Graham Jones.</marc:subfield>
+    </marc:datafield>
+    <marc:datafield ind1="f" ind2="f" tag="999">
+      <marc:subfield code="t">0</marc:subfield>
+    </marc:datafield>
+  </marc:record>
+</collection>

--- a/test/src/org/solrmarc/index/indexer/IndexWithIdChangeTests.java
+++ b/test/src/org/solrmarc/index/indexer/IndexWithIdChangeTests.java
@@ -1,0 +1,119 @@
+package org.solrmarc.index.indexer;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
+import org.marc4j.MarcXmlReader;
+import org.solrmarc.driver.Indexer;
+import org.solrmarc.driver.RecordAndDoc;
+import org.solrmarc.index.indexer.ValueIndexerFactory;
+import org.solrmarc.index.indexer.MultiValueIndexer;
+import org.solrmarc.solr.SolrProxy;
+
+import java.io.IOException;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Collections;
+import java.util.concurrent.BlockingQueue;
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.verify;
+
+
+public class IndexWithIdChangeTests
+{
+    private final static String inputfilename="./test/data/records/jones_recs.xml";
+    private static ValueIndexerFactory factory;
+    static
+    {
+        factory = ValueIndexerFactory.initialize(new String[]{System.getProperty("test.data.dir", "test/data")});
+    }
+
+    private List<RecordAndDoc> extractDocuments(final SolrProxy proxy) throws IOException
+    {
+        final ArgumentCaptor<RecordAndDoc> mapArgumentCaptor = ArgumentCaptor.forClass(RecordAndDoc.class);
+        verify(proxy).addDoc(mapArgumentCaptor.capture());
+        return mapArgumentCaptor.getAllValues();
+    }
+
+    @Test
+    public void testIndexDeleteUnmodifiedId() throws Exception
+    {
+        final String[] configSpecs = {
+            "id = 001, first",
+            "suppressed = 999t?($t == 1), DeleteRecordIfFieldNotEmpty"
+        };
+        final List<AbstractValueIndexer<?>> valueIndexers = factory.createValueIndexers(configSpecs);
+        final SolrProxy proxy = Mockito.mock(SolrProxy.class);
+        final Indexer indexer = new Indexer(valueIndexers, proxy);
+
+        InputStream input = new BufferedInputStream(new FileInputStream(inputfilename));
+        indexer.indexToSolr(new MarcXmlReader(input));
+
+        List<RecordAndDoc> documents = extractDocuments(proxy);
+        assertEquals(1, documents.size());
+        assertEquals("in00005570501", documents.get(0).getRec().getControlNumber());
+        assertEquals("in00005570501", documents.get(0).getDoc().getFieldValue("id"));
+
+        Field delQField = Indexer.class.getDeclaredField("delQ");
+        delQField.setAccessible(true);
+        BlockingQueue<String> delQ = (BlockingQueue<String>) delQField.get(indexer);
+        assertEquals(1, delQ.size());
+        assertEquals("in00006878693", delQ.peek());
+    }
+
+    @Test
+    public void testIndexDeleteModifiedId() throws Exception
+    {
+        final String[] configSpecs = {
+            "id = 001, (pattern_map.id_prefix), first",
+            "pattern_map.id_prefix.pattern_0 = (.+)=>folio.$1",
+            "suppressed = 999t?($t == 1), DeleteRecordIfFieldNotEmpty"
+        };
+        final List<AbstractValueIndexer<?>> valueIndexers = factory.createValueIndexers(configSpecs);
+        final SolrProxy proxy = Mockito.mock(SolrProxy.class);
+        final Indexer indexer = new Indexer(valueIndexers, proxy);
+
+        InputStream input = new BufferedInputStream(new FileInputStream(inputfilename));
+        indexer.indexToSolr(new MarcXmlReader(input));
+
+        List<RecordAndDoc> documents = extractDocuments(proxy);
+        assertEquals(1, documents.size());
+        assertEquals("folio.in00005570501", documents.get(0).getDoc().getFieldValue("id"));
+
+        Field delQField = Indexer.class.getDeclaredField("delQ");
+        delQField.setAccessible(true);
+        BlockingQueue<String> delQ = (BlockingQueue<String>) delQField.get(indexer);
+        assertEquals(1, delQ.size());
+        assertEquals("folio.in00006878693", delQ.peek());
+    }
+
+    @Test
+    public void testIndexDeleteUndefinedId() throws Exception
+    {
+        final String[] configSpecs = {
+            "suppressed = 999t?($t == 1), DeleteRecordIfFieldNotEmpty"
+        };
+        final List<AbstractValueIndexer<?>> valueIndexers = factory.createValueIndexers(configSpecs);
+        final SolrProxy proxy = Mockito.mock(SolrProxy.class);
+        final Indexer indexer = new Indexer(valueIndexers, proxy);
+
+        InputStream input = new BufferedInputStream(new FileInputStream(inputfilename));
+        indexer.indexToSolr(new MarcXmlReader(input));
+
+        List<RecordAndDoc> documents = extractDocuments(proxy);
+        assertEquals(1, documents.size());
+        assertEquals("in00005570501", documents.get(0).getRec().getControlNumber());
+        assertNull(documents.get(0).getDoc().getFieldValue("id"));
+
+        Field delQField = Indexer.class.getDeclaredField("delQ");
+        delQField.setAccessible(true);
+        BlockingQueue<String> delQ = (BlockingQueue<String>) delQField.get(indexer);
+        assertEquals(1, delQ.size());
+        assertEquals("in00006878693", delQ.peek());
+    }
+}


### PR DESCRIPTION
When indexing, if the Solr id is modified from the control number, solrmarc would later still attempt to reference the Solr document assuming the original controlnumber was the Solr id.

For example with SolrMarcIndexerException.DELETE, this would result in Solr records being mismatched and not deleted.

Also, unittests for Indexer were failing with newer Java. Added `--add-opens=java.base/java.lang=ALL-UNNAMED` to the and `test` target for the build to get reflection working.