### PR TITLE
Fix log message typo "Commiting"

### DIFF
--- a/src/org/solrmarc/driver/Indexer.java
+++ b/src/org/solrmarc/driver/Indexer.java
@@ -594,10 +594,10 @@ public class Indexer
         try
         {
             if ( commitAtEnd) {
-                logger.info("Commmiting updates to Solr");
+                logger.info("Commmitting updates to Solr");
                 solrProxy.commit(false);
             } else {   // mlevy
-                logger.info("Not commmiting updates to Solr");
+                logger.info("Not commmitting updates to Solr");
             }
         }
         catch (SolrRuntimeException e)


### PR DESCRIPTION
Not trying to be the spelling police here. :) I was grepping through the huge log output to find when commits were happening, and couldn't find it because of the typo.